### PR TITLE
Fix isByteResponse returning empty body in BuildResponse

### DIFF
--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -217,34 +217,37 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 
 	bodyReader = resp.Body
 
-	if !isByteResponse {
-		// Try to preview a single byte of the body reader to prevent EOF caused by empty bodies.
-		// This is probably the best way of reliably detecting empty response bodies,
-		// especially when the content-length response header is not present.
-		firstByte := make([]byte, 1)
-		n, err := io.ReadFull(resp.Body, firstByte)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return Response{}, NewTLSClientError(err)
-		}
+	// Preview a single byte first so we can cleanly return an empty body
+	// without letting charset.NewReader's auto-detection raise EOF on
+	// zero-length responses. The peeked byte is stitched back on via
+	// io.MultiReader before we hand the stream to either the charset reader
+	// (text responses) or io.ReadAll (byte responses).
+	firstByte := make([]byte, 1)
+	n, err := io.ReadFull(resp.Body, firstByte)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return Response{}, NewTLSClientError(err)
+	}
 
-		if n == 0 {
-			respBodyBytes = nil
-		} else {
-			bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
+	if n == 0 {
+		respBodyBytes = nil
+	} else {
+		bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
+
+		if !isByteResponse {
 			// Automatically detect the charset for non-byte responses
 			bodyReader, err = charset.NewReader(bodyReader, ct)
 			if err != nil {
 				return Response{}, NewTLSClientError(err)
 			}
+		}
 
-			if input.StreamOutputPath != nil {
-				respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
-			} else {
-				respBodyBytes, err = io.ReadAll(bodyReader)
-			}
-			if err != nil {
-				return Response{}, NewTLSClientError(err)
-			}
+		if input.StreamOutputPath != nil {
+			respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
+		} else {
+			respBodyBytes, err = io.ReadAll(bodyReader)
+		}
+		if err != nil {
+			return Response{}, NewTLSClientError(err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix for a regression introduced by upstream commit `d0fc595` ("fix EOF errors caused by the charset reader by previewing the response body whether at least one byte exists"), which took out bet-hero's Marca Apuestas scraper as soon as `bh_1.0.1` shipped.

## Why

`d0fc595` added a first-byte preview + `charset.NewReader` wrapping to the non-byte-response path of `BuildResponse` to keep the charset reader from raising EOF on zero-length responses. But it moved `io.ReadAll` **inside** the `!isByteResponse` branch, so the `isByteResponse=true` code path never reads the body at all. `respBodyBytes` stays `nil`, `http.DetectContentType(nil)` returns `text/plain; charset=utf-8`, and the final payload becomes a data URI with an empty base64 body:

```
data:text/plain; charset=utf-8;base64,
```

Marca Apuestas is the only bet-hero scraper passing `is_byte_response=True` — it fetches LZMA-packed sportswidget `/v2/getslice` payloads and decodes them client-side. Every request started raising `ValueError: Marca Apuestas payload too short for header: 0 bytes`.

## Fix

Move the first-byte peek + `io.MultiReader` + `io.ReadAll` out of the `!isByteResponse` branch, and only wrap in `charset.NewReader` when `!isByteResponse`. The EOF guard `d0fc595` shipped still works (if `n == 0` we set `respBodyBytes = nil` and skip everything); byte responses get their bytes back.

## Verification

Built `bh_1.0.2` locally and reran Marca Apuestas against its prod proxy pool:

- `/v2/getmeta` -> `application/json`, 128 bytes, unchanged
- `/v2/getslice/..._2_es_..._0` with `is_byte_response=True` -> `data:application/octet-stream;base64,XQAA...` with **91,885 bytes** decoded, matching pre-sync behavior
- Marca Apuestas scraper end-to-end: 1010 events fetched (was 0-byte `ValueError` on `bh_1.0.1`)

Non-byte responses on zero-length bodies still terminate cleanly (the EOF guard path kicks in before `charset.NewReader`).

## Test plan

- [x] Rebuilt darwin-arm64, darwin-amd64, linux-amd64 (musl + glibc), linux-arm64, windows 32/64 all compile from this branch
- [x] Marca Apuestas end-to-end regression vs. bet-hero prod proxies
- [ ] Suggest adding a unit test for `BuildResponse` with `isByteResponse=true` + non-empty + empty body paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)